### PR TITLE
Repo: fix memory leak in WaitingList

### DIFF
--- a/ipfs.nim
+++ b/ipfs.nim
@@ -19,7 +19,7 @@ proc info*(ipfs: Ipfs): PeerInfo =
   ipfs.switch.peerInfo
 
 proc start*(_: type Ipfs, addresses: seq[MultiAddress]): Future[Ipfs] {.async.} =
-  let repo = Repo()
+  let repo = Repo.new()
   let switch = Switch.create()
   let bitswap = Bitswap.start(switch, repo)
   switch.peerInfo.addrs.add(addresses)

--- a/ipfs/bitswap.nim
+++ b/ipfs/bitswap.nim
@@ -21,7 +21,7 @@ proc startExchange(bitswap: Bitswap, stream: BitswapStream) =
   let exchange = Exchange.start(bitswap.repo, stream)
   bitswap.exchanges.add(exchange)
 
-proc start*(_: type Bitswap, switch: Switch, repo = Repo()): Bitswap =
+proc start*(_: type Bitswap, switch: Switch, repo = Repo.new()): Bitswap =
   let bitswap = Bitswap(repo: repo, switch: switch)
   let protocol = BitswapProtocol.new()
   proc acceptLoop {.async.} =

--- a/ipfs/repo.nim
+++ b/ipfs/repo.nim
@@ -14,6 +14,9 @@ type
     storage: Table[Cid, IpfsObject]
     waiting: WaitingList[Cid]
 
+proc new*(_: type Repo): Repo =
+  Repo(waiting: WaitingList[Cid]())
+
 proc hash(id: Cid): Hash =
   hash($id)
 

--- a/ipfs/repo/waitinglist.nim
+++ b/ipfs/repo/waitinglist.nim
@@ -1,7 +1,7 @@
 import std/tables
 import pkg/chronos
 
-type WaitingList*[T] = object
+type WaitingList*[T] = ref object
   futures: Table[T, seq[Future[void]]]
 
 proc wait*[T](list: var WaitingList, item: T, timeout: Duration): Future[void] =

--- a/ipfs/repo/waitinglist.nim
+++ b/ipfs/repo/waitinglist.nim
@@ -1,20 +1,32 @@
 import std/tables
+import std/sequtils
+import std/sugar
 import pkg/chronos
 
 type WaitingList*[T] = ref object
   futures: Table[T, seq[Future[void]]]
 
-proc wait*[T](list: var WaitingList, item: T, timeout: Duration): Future[void] =
+proc remove[T](list: WaitingList[T], item: T, future: Future[void]) =
+  list.futures[item].keepIf(x => x != future)
+  if list.futures[item].len == 0:
+    list.futures.del(item)
+
+proc wait*[T](list: WaitingList[T], item: T, timeout: Duration): Future[void] =
   let future = newFuture[void]("waitinglist.wait")
   proc onTimeout(_: pointer) =
     if not future.finished:
       future.complete()
+      list.remove(item, future)
   discard setTimer(Moment.fromNow(timeout), onTimeout, nil)
   list.futures.mgetOrPut(item, @[]).add(future)
   future
 
-proc deliver*[T](list: var WaitingList, item: T) =
+proc deliver*[T](list: WaitingList[T], item: T) =
   if list.futures.hasKey(item):
     for future in list.futures[item]:
       future.complete()
     list.futures.del(item)
+
+proc count*[T](list: WaitingList[T]): int =
+  for x in list.futures.values:
+    result += x.len

--- a/tests/ipfs/testRepo.nim
+++ b/tests/ipfs/testRepo.nim
@@ -8,7 +8,7 @@ suite "repo":
   var repo: Repo
 
   setup:
-    repo = Repo()
+    repo = Repo.new()
 
   test "stores IPFS objects":
     repo.store(obj)

--- a/tests/ipfs/testWaitingList.nim
+++ b/tests/ipfs/testWaitingList.nim
@@ -29,3 +29,28 @@ suite "waiting list":
     check not wait.finished
     await sleepAsync(100.milliseconds)
     check wait.finished
+
+  test "timeout does nothing when item already delivered":
+    let wait = list.wait("apple", 100.milliseconds)
+    list.deliver("apple")
+    await sleepAsync(100.milliseconds)
+    check wait.finished
+
+  test "tracks the amount of waiting futures":
+    check list.count == 0
+    asyncSpawn list.wait("apple", 1.minutes)
+    check list.count == 1
+    asyncSpawn list.wait("orange", 1.minutes)
+    check list.count == 2
+    asyncSpawn list.wait("apple", 1.minutes)
+    check list.count == 3
+
+  test "removes future when item is delivered":
+    asyncSpawn list.wait("apple", 1.minutes)
+    list.deliver("apple")
+    check list.count == 0
+
+  test "removes future after timeout":
+    asyncSpawn list.wait("apple", 100.milliseconds)
+    await sleepAsync(100.milliseconds)
+    check list.count == 0


### PR DESCRIPTION
The WaitingList only cleaned up the waiting futures when an item became available, but forgot to clean up the waiting futures that timed out. This PR fixes that.