### PR TITLE
Support Nim 1.2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        nim: [stable, 1.2.6]
     steps:
     - uses: actions/checkout@v2
     - uses: iffy/install-nim@v3
+      with:
+        version: ${{ matrix.nim }}
+    - name: Build
+      run: nimble install -y
     - name: Test
       run: nimble test -y

--- a/ipfs.nimble
+++ b/ipfs.nimble
@@ -3,7 +3,7 @@ author = "Dagger Team"
 description = "Decentralized storage in Nim"
 license = "MIT"
 
-requires "nim >= 1.4.2 & < 2.0.0"
+requires "nim >= 1.2.6 & < 2.0.0"
 requires "libp2p >= 0.0.2 & < 0.1.0"
 requires "chronos >= 2.5.2 & < 3.0.0"
 requires "protobufserialization >= 0.2.0 & < 0.3.0"


### PR DESCRIPTION
Signals support for Nim 1.2.6  in the Nimble file.
Runs CI on Nim 1.2.6 in addition to the latest stable Nim.