### PR TITLE
Chunking: fix erroneous cast from bytes to string

### DIFF
--- a/ipfs.nimble
+++ b/ipfs.nimble
@@ -4,6 +4,7 @@ description = "Decentralized storage in Nim"
 license = "MIT"
 
 requires "nim >= 1.4.2 & < 2.0.0"
+requires "stew >= 0.1.0 & < 0.2.0"
 requires "libp2p >= 0.0.2 & < 0.1.0"
 requires "chronos >= 2.5.2 & < 3.0.0"
 requires "protobufserialization >= 0.2.0 & < 0.3.0"

--- a/ipfs/chunking.nim
+++ b/ipfs/chunking.nim
@@ -7,4 +7,5 @@ proc createObject*(file: File): IpfsObject =
   IpfsObject(data: cast[seq[byte]](contents))
 
 proc writeToFile*(obj: IpfsObject, output: File) =
-  output.write(cast[string](obj.data))
+  if obj.data.len > 0:
+    discard output.writeBuffer(unsafeAddr obj.data[0], obj.data.len)

--- a/ipfs/chunking.nim
+++ b/ipfs/chunking.nim
@@ -1,10 +1,11 @@
+import pkg/stew/byteutils
 import ./ipfsobject
 
 export ipfsobject
 
 proc createObject*(file: File): IpfsObject =
   let contents = file.readAll()
-  IpfsObject(data: cast[seq[byte]](contents))
+  IpfsObject(data: contents.toBytes)
 
 proc writeToFile*(obj: IpfsObject, output: File) =
   if obj.data.len > 0:


### PR DESCRIPTION
Fixes intermittent test failure on Windows, such as:
https://github.com/status-im/nim-dagger/runs/1855282285?check_suite_focus=true