### PR TITLE
Fix warnings

### DIFF
--- a/dagger/blockexchange/engine.nim
+++ b/dagger/blockexchange/engine.nim
@@ -8,7 +8,6 @@
 ## those terms.
 
 import std/sequtils
-import std/algorithm
 
 import pkg/chronos
 import pkg/chronicles

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,1 +1,2 @@
 -d:"chronicles_log_level=INFO"
+--warning:LockLevel:off

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,3 @@
 -d:"chronicles_log_level=INFO"
 --warning:LockLevel:off
+--warning:ObservableStores:off

--- a/tests/dagger/testblockexc.nim
+++ b/tests/dagger/testblockexc.nim
@@ -3,3 +3,5 @@ import ./blockexc/testnetwork
 import ./blockexc/protobuf/testpayments as testprotobufpayments
 import ./blockexc/protobuf/testpresence
 import ./blockexc/engine/testpayments as testenginepayments
+
+{.warning[UnusedImport]: off.}

--- a/tests/dagger/testblockset.nim
+++ b/tests/dagger/testblockset.nim
@@ -1,4 +1,3 @@
-
 import pkg/chronos
 import pkg/questionable
 import pkg/questionable/results
@@ -7,7 +6,6 @@ import pkg/libp2p
 import pkg/stew/byteutils as stew
 
 import pkg/dagger/chunker
-import pkg/dagger/rng
 import pkg/dagger/blocktype as bt
 import pkg/dagger/blockstream
 import pkg/dagger/blockset

--- a/tests/dagger/teststores.nim
+++ b/tests/dagger/teststores.nim
@@ -1,2 +1,4 @@
 import ./stores/testblockexc
 import ./stores/testblockstore
+
+{.warning[UnusedImport]: off.}


### PR DESCRIPTION
Fixes unused imports.

Disables `LockLevel` and `ObservableStores` warnings because they are
not relevant for our codebase and obfuscate other warnings that are relevant.