### PR TITLE
add env.sh shim to project root

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# We use ${BASH_SOURCE[0]} instead of $0 to allow sourcing this file
+# and we fall back to a Zsh-specific special var to also support Zsh.
+REL_PATH="$(dirname ${BASH_SOURCE[0]:-${(%):-%x}})"
+ABS_PATH="$(cd ${REL_PATH}; pwd)"
+source ${ABS_PATH}/vendor/nimbus-build-system/scripts/env.sh


### PR DESCRIPTION
`env.sh` is copied verbatim from: https://github.com/status-im/nimbus-build-system#envsh

---

This is simply for convenience; see e.g. https://github.com/status-im/nim-dagger/pull/33#issuecomment-996076749.