### PR TITLE
Nim wrapper for Leopard-RS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
         run: |
           brew install libomp
           echo "$(brew --prefix)/opt/llvm/bin" >> $GITHUB_PATH
+          echo "CC=$(brew --prefix)/opt/llvm/bin/clang" >> $GITHUB_ENV
+          echo "CXX=$(brew --prefix)/opt/llvm/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS=-L$(brew --prefix)/opt/libomp/lib -L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib" >> $GITHUB_ENV
           echo "LIBLEOPARD_CMAKE_FLAGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix)/opt/llvm/bin/clang++" >> $GITHUB_ENV
           echo "NIM_EXTRA_PARAMS=--passL:-fopenmp --passL:-L$(brew --prefix)/opt/libomp/lib" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        branch: [v1.4.6]
         target:
           # Unit tests
           - os: linux
@@ -35,7 +34,7 @@ jobs:
           - target:
               os: windows
             builder: windows-2019
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (${{ matrix.branch }})'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout nim-dagger
@@ -93,6 +92,7 @@ jobs:
           EOF
           chmod 755 external/bin/gcc external/bin/g++
           echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
+          echo "LIBLEOPARD_CMAKE_FLAGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32" >> $GITHUB_ENV
 
       - name: Restore MinGW-W64 (Windows) from cache
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,15 @@ jobs:
           echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
           echo "LIBLEOPARD_CMAKE_FLAGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32" >> $GITHUB_ENV
 
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install libomp
+          echo "$(brew --prefix)/opt/llvm/bin" >> $GITHUB_PATH
+          echo "LDFLAGS=-L$(brew --prefix)/opt/libomp/lib -L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib" >> $GITHUB_ENV
+          echo "LIBLEOPARD_CMAKE_FLAGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix)/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix)/opt/llvm/bin/clang++" >> $GITHUB_ENV
+          echo "NIM_EXTRA_PARAMS=--passL:-fopenmp --passL:-L$(brew --prefix)/opt/libomp/lib" >> $GITHUB_ENV
+
       - name: Restore MinGW-W64 (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-mingw-cache
@@ -173,4 +182,4 @@ jobs:
         shell: bash
         working-directory: nim-dagger
         run: |
-          make test
+          make V=1 test

--- a/.gitmodules
+++ b/.gitmodules
@@ -162,3 +162,8 @@
 [submodule "vendor/lrucache.nim"]
 	path = vendor/lrucache.nim
 	url = https://github.com/status-im/lrucache.nim
+[submodule "vendor/leopard"]
+	path = vendor/leopard
+	url = https://github.com/catid/leopard
+	ignore = untracked
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -96,14 +96,16 @@ NIM_PARAMS += --passC:"-I$(shell dirname $(LIBLEOPARD_HEADER))" --passL:"$(LIBLE
 endif
 
 ifneq ($(detected_OS),macOS)
-NIM_PARAMS += --passL:"-fopenmp"
+NIM_PARAMS += --passL:-fopenmp
 endif
+
+NIM_PARAMS += $(NIM_EXTRA_PARAMS)
 
 $(LIBLEOPARD):
 	cd vendor/leopard && \
 	mkdir -p build && cd build && \
 	cmake .. $(LIBLEOPARD_CMAKE_FLAGS) && \
-	$(MAKE)
+	$(MAKE) libleopard
 
 leopard: $(LIBLEOPARD)
 

--- a/dagger/leopard.nim
+++ b/dagger/leopard.nim
@@ -1,0 +1,5 @@
+const header = "leopard.h"
+
+{.pragma: leo, cdecl, header: header, importCpp.}
+
+proc leo_init*(): cint {.leo.}

--- a/dagger/leopard.nim
+++ b/dagger/leopard.nim
@@ -1,5 +1,32 @@
-const header = "leopard.h"
+type
+  LeopardResult* {.pure.} = enum
+    Leopard_CallInitialize = -7.cint
+    Leopard_Platform       = -6.cint
+    Leopard_InvalidInput   = -5.cint
+    Leopard_InvalidCounts  = -4.cint
+    Leopard_InvalidSize    = -3.cint
+    Leopard_TooMuchData    = -2.cint
+    Leopard_NeedMoreData   = -1.cint
+    Leopard_Success        =  0.cint
+
+const
+  header = "leopard.h"
 
 {.pragma: leo, cdecl, header: header, importCpp.}
 
 proc leo_init*(): cint {.leo.}
+
+func leo_result_string*(res: LeopardResult): cstring {.leo.}
+
+func leo_encode_work_count*(original_count, recovery_count: cuint): cuint
+  {.leo.}
+
+proc leo_encode*(buffer_bytes: uint64, original_count, recovery_count,
+  work_count: cuint, original_data, work_data: pointer): LeopardResult {.leo.}
+
+func leo_decode_work_count*(original_count, recovery_count: cuint): cuint
+  {.leo.}
+
+proc leo_decode*(buffer_bytes: uint64, original_count, recovery_count,
+  work_count: cuint, original_data, recovery_data, work_data: pointer):
+  LeopardResult {.leo.}

--- a/dagger/leopard.nim
+++ b/dagger/leopard.nim
@@ -12,21 +12,22 @@ type
 const
   header = "leopard.h"
 
-{.pragma: leo, cdecl, header: header, importCpp.}
+{.pragma: leo, cdecl, header: header.}
 
-proc leo_init*(): cint {.leo.}
+proc leo_init*(): cint {.leo, importCpp.}
 
-func leo_result_string*(res: LeopardResult): cstring {.leo.}
+func leo_result_string*(res: LeopardResult): cstring {.leo, importc.}
 
 func leo_encode_work_count*(original_count, recovery_count: cuint): cuint
-  {.leo.}
+  {.leo, importc.}
 
 proc leo_encode*(buffer_bytes: uint64, original_count, recovery_count,
-  work_count: cuint, original_data, work_data: pointer): LeopardResult {.leo.}
+  work_count: cuint, original_data, work_data: pointer): LeopardResult
+  {.leo, importc.}
 
 func leo_decode_work_count*(original_count, recovery_count: cuint): cuint
-  {.leo.}
+  {.leo, importc.}
 
 proc leo_decode*(buffer_bytes: uint64, original_count, recovery_count,
   work_count: cuint, original_data, recovery_data, work_data: pointer):
-  LeopardResult {.leo.}
+  LeopardResult {.leo, importc.}

--- a/tests/dagger/testleopard.nim
+++ b/tests/dagger/testleopard.nim
@@ -1,7 +1,6 @@
-# import std/os
-# import std/random
 import std/sequtils
 import std/strformat
+import std/strutils
 
 import pkg/dagger/leopard
 import pkg/stew/byteutils
@@ -11,8 +10,6 @@ type
     original_count: cuint
     recovery_count: cuint
     buffer_bytes  : cuint
-    loss_count    : cuint
-    seed          : cuint
 
   Vec = seq[pointer]
 
@@ -20,75 +17,45 @@ proc init(
     T: type TestParameters,
     original_count: cuint = 100,
     recovery_count: cuint = 10,
-    buffer_bytes  : cuint = 64000,
-    loss_count    : cuint = 32768,
-    seed          : cuint = 2): T =
+    buffer_bytes  : cuint = 64000): T =
   T(original_count: original_count,
     recovery_count: recovery_count,
-    buffer_bytes  : buffer_bytes,
-    loss_count    : loss_count,
-    seed          : seed)
+    buffer_bytes  : buffer_bytes)
 
 proc new(T: type Vec, input: seq[seq[byte]]): T =
   input.mapIt(cast[pointer](unsafeAddr it[0]))
 
-proc benchmark(params: TestParameters) =
+proc test(params: TestParameters) =
+  let
+    deadbeef64 = @[
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef,
+      0xde, 0xad, 0xbe, 0xef
+    ].mapIt(it.byte)
+
   var
-    # original_data = newSeqWith(params.original_count.int,
-    #   newSeq[byte](params.buffer_bytes))
-
-    # original_data_0 = newSeqWith(params.original_count.int, hello.toBytes)
-    # original_data = Vec.new(original_data_0)
-
-    hello01 = "hello world01                                                   "
-    hello02 = "hello world02                                                   "
-    hello03 = "hello world03                                                   "
-    hello04 = "hello world04                                                   "
-    hello05 = "hello world05                                                   "
-    hello06 = "hello world06                                                   "
-    hello07 = "hello world07                                                   "
-    hello08 = "hello world08                                                   "
-    hello09 = "hello world09                                                   "
-    hello10 = "hello world10                                                   "
-    hello11 = "hello world11                                                   "
-    hello12 = "hello world12                                                   "
-    hello13 = "hello world13                                                   "
-    hello14 = "hello world14                                                   "
-    hello15 = "hello world15                                                   "
-    hello16 = "hello world16                                                   "
-    hello17 = "hello world17                                                   "
-    hello18 = "hello world18                                                   "
-    hello19 = "hello world19                                                   "
-    hello20 = "hello world20                                                   "
-
-    original_data_0 = @[
-      hello01.toBytes,
-      hello02.toBytes,
-      hello03.toBytes,
-      hello04.toBytes,
-      hello05.toBytes,
-      hello06.toBytes,
-      hello07.toBytes,
-      hello08.toBytes,
-      hello09.toBytes,
-      hello10.toBytes,
-      hello11.toBytes,
-      hello12.toBytes,
-      hello13.toBytes,
-      hello14.toBytes,
-      hello15.toBytes,
-      hello16.toBytes,
-      hello17.toBytes,
-      hello18.toBytes,
-      hello19.toBytes,
-      hello20.toBytes
-    ]
-
+    original_data_0 = newSeqWith(params.original_count.int, deadbeef64)
     original_data = Vec.new(original_data_0)
 
-  # debugEcho $original_data_0.mapIt(repr it)
-  # debugEcho $original_data.mapIt(repr cast[seq[byte]](cast[pointer](cast[int](it) - 16)))
-  debugEcho $original_data.mapIt(cast[int](it))
+  debugEcho "\nORIGINAL DATA"
+  debugEcho "-------------\n"
+  debugEcho $original_data_0.mapIt(it.mapIt(it.toHex(2).toLowerAscii))
+
+  # debugEcho $original_data.mapIt("0x" & (cast[int](it) - 16).toHex(9).toLowerAscii)
+  # debugEcho $original_data.mapIt((cast[seq[byte]](cast[pointer](cast[int](it) - 16))).mapIt(it.toHex(2).toLowerAscii))
 
   let
     encode_work_count = leo_encode_work_count(params.original_count,
@@ -96,7 +63,7 @@ proc benchmark(params: TestParameters) =
     decode_work_count = leo_decode_work_count(params.original_count,
       params.recovery_count)
 
-  debugEcho "encode_work_count: " & $encode_work_count
+  debugEcho "\nencode_work_count: " & $encode_work_count
   debugEcho "decode_work_count: " & $decode_work_count
 
   let
@@ -127,19 +94,25 @@ proc benchmark(params: TestParameters) =
 
   debugEcho "encodeResult: " & $leo_result_string(encodeResult)
 
-  original_data[0]  = nil
-  original_data[17] = nil
+  original_data[53]  = nil
+  original_data[199] = nil
 
-  encode_work_data[0] = nil
-  encode_work_data[1] = nil
-  # encode_work_data[2] = nil
-  encode_work_data[3] = nil
-  encode_work_data[4] = nil
-  encode_work_data[5] = nil
-  encode_work_data[6] = nil
-  encode_work_data[7] = nil
-  encode_work_data[8] = nil
-  # encode_work_data[9] = nil
+  encode_work_data[0]  = nil
+  encode_work_data[1]  = nil
+  encode_work_data[2]  = nil
+  encode_work_data[3]  = nil
+  encode_work_data[4]  = nil
+  encode_work_data[5]  = nil
+  encode_work_data[6]  = nil
+  # encode_work_data[7]  = nil
+  encode_work_data[8]  = nil
+  encode_work_data[9]  = nil
+  encode_work_data[10] = nil
+  # encode_work_data[11] = nil
+  encode_work_data[12] = nil
+  encode_work_data[13] = nil
+  encode_work_data[14] = nil
+  encode_work_data[15] = nil
 
   let
     decodeResult = leo_decode(
@@ -154,27 +127,34 @@ proc benchmark(params: TestParameters) =
 
   debugEcho "decodeResult: " & $leo_result_string(decodeResult)
 
-  debugEcho $original_data.mapIt((if it.isNil: @[] else: cast[seq[byte]](cast[pointer](cast[int](it) - 16))).len)
-  debugEcho $encode_work_data.mapIt((if it.isNil: @[] else: cast[seq[byte]](cast[pointer](cast[int](it) - 16))).len)
-  debugEcho $decode_work_data.mapIt(cast[seq[byte]](cast[pointer](cast[int](it) - 16)).len)
-  # debugEcho $decode_work_data.mapIt(cast[seq[byte]](cast[pointer](cast[int](it) - 16)))
+  debugEcho "\nDECODED DATA"
+  debugEcho "------------\n"
+  debugEcho $decode_work_data.mapIt((cast[seq[byte]](cast[pointer](cast[int](it) - 16))).mapIt(it.toHex(2).toLowerAscii))
 
 proc main() =
   if leo_init() != 0: raise (ref Defect)(msg: "Leopard failed to initialize")
 
-  var params = TestParameters.init(buffer_bytes = 64, original_count = 20)
+  # https://github.com/catid/leopard/issues/12
+  # https://www.cs.cmu.edu/~guyb/realworld/reedsolomon/reed_solomon_codes.html
+
+  # RS(255, 239)
+  # ------------
+  # original_count = 239
+  # recovery_count = 255 - 239 = 16
+
+  var params = TestParameters.init(
+    original_count = 239,
+    recovery_count = 16,
+    buffer_bytes = 64
+  )
 
   debugEcho fmt(
     "Parameters: "                              &
     "[original count={params.original_count}] " &
     "[recovery count={params.recovery_count}] " &
-    "[buffer bytes={params.buffer_bytes}] "     &
-    "[loss count={params.loss_count}] "         &
-    "[random seed={params.seed}]"
+    "[buffer bytes={params.buffer_bytes}] "
   )
 
-  benchmark params
+  test params
 
-when true: # isMainModule:
-  # randomize()
-  main()
+main()

--- a/tests/dagger/testleopard.nim
+++ b/tests/dagger/testleopard.nim
@@ -1,6 +1,97 @@
+# import std/os
+# import std/random
+import std/sequtils
+import std/strformat
+
 import pkg/dagger/leopard
 
-let lin = leo_init()
+type
+  TestParameters = object
+    original_count: cuint
+    recovery_count: cuint
+    buffer_bytes  : cuint
+    loss_count    : cuint
+    seed          : cuint
 
-echo ""
-echo "leo_init() return code: " & $lin
+proc init(
+    T: type TestParameters,
+    original_count: cuint = 100,
+    recovery_count: cuint = 10,
+    buffer_bytes  : cuint = 64000,
+    loss_count    : cuint = 32768,
+    seed          : cuint = 2): T =
+  T(original_count: original_count,
+    recovery_count: recovery_count,
+    buffer_bytes  : buffer_bytes,
+    loss_count    : loss_count,
+    seed          : seed)
+
+proc benchmark(params: TestParameters) =
+  var
+    original_data = newSeqWith(params.original_count.int,
+      newSeq[byte](params.buffer_bytes))
+
+  let
+    encode_work_count = leo_encode_work_count(params.original_count,
+      params.recovery_count)
+    decode_work_count = leo_decode_work_count(params.original_count,
+      params.recovery_count)
+
+  debugEcho "encode_work_count: " & $encode_work_count
+  debugEcho "decode_work_count: " & $decode_work_count
+
+  let
+    total_bytes = (params.buffer_bytes * params.original_count).uint64
+
+  debugEcho "total_bytes: " & $total_bytes
+
+  var
+    encode_work_data = newSeqWith(encode_work_count.int,
+      newSeq[byte](params.buffer_bytes))
+    decode_work_data = newSeqWith(decode_work_count.int,
+      newSeq[byte](params.buffer_bytes))
+
+  let
+    encodeResult = leo_encode(
+      params.buffer_bytes,
+      params.original_count,
+      params.recovery_count,
+      encode_work_count,
+      addr original_data[0],
+      addr encode_work_data[0]
+    )
+
+  debugEcho "encodeResult: " & $leo_result_string(encodeResult)
+
+  let
+    decodeResult = leo_decode(
+      params.buffer_bytes,
+      params.original_count,
+      params.recovery_count,
+      decode_work_count,
+      addr original_data[0],
+      addr encode_work_data[0],
+      addr decode_work_data[0]
+    )
+
+  debugEcho "decodeResult: " & $leo_result_string(decodeResult)
+
+proc main() =
+  if leo_init() != 0: raise (ref Defect)(msg: "Leopard failed to initialize")
+
+  var params = TestParameters.init
+
+  debugEcho fmt(
+    "Parameters: "                              &
+    "[original count={params.original_count}] " &
+    "[recovery count={params.recovery_count}] " &
+    "[buffer bytes={params.buffer_bytes}] "     &
+    "[loss count={params.loss_count}] "         &
+    "[random seed={params.seed}]"
+  )
+
+  benchmark params
+
+when true: # isMainModule:
+  # randomize()
+  main()

--- a/tests/dagger/testleopard.nim
+++ b/tests/dagger/testleopard.nim
@@ -4,6 +4,7 @@ import std/sequtils
 import std/strformat
 
 import pkg/dagger/leopard
+import pkg/stew/byteutils
 
 type
   TestParameters = object
@@ -12,6 +13,8 @@ type
     buffer_bytes  : cuint
     loss_count    : cuint
     seed          : cuint
+
+  Vec = seq[pointer]
 
 proc init(
     T: type TestParameters,
@@ -26,10 +29,66 @@ proc init(
     loss_count    : loss_count,
     seed          : seed)
 
+proc new(T: type Vec, input: seq[seq[byte]]): T =
+  input.mapIt(cast[pointer](unsafeAddr it[0]))
+
 proc benchmark(params: TestParameters) =
   var
-    original_data = newSeqWith(params.original_count.int,
-      newSeq[byte](params.buffer_bytes))
+    # original_data = newSeqWith(params.original_count.int,
+    #   newSeq[byte](params.buffer_bytes))
+
+    # original_data_0 = newSeqWith(params.original_count.int, hello.toBytes)
+    # original_data = Vec.new(original_data_0)
+
+    hello01 = "hello world01                                                   "
+    hello02 = "hello world02                                                   "
+    hello03 = "hello world03                                                   "
+    hello04 = "hello world04                                                   "
+    hello05 = "hello world05                                                   "
+    hello06 = "hello world06                                                   "
+    hello07 = "hello world07                                                   "
+    hello08 = "hello world08                                                   "
+    hello09 = "hello world09                                                   "
+    hello10 = "hello world10                                                   "
+    hello11 = "hello world11                                                   "
+    hello12 = "hello world12                                                   "
+    hello13 = "hello world13                                                   "
+    hello14 = "hello world14                                                   "
+    hello15 = "hello world15                                                   "
+    hello16 = "hello world16                                                   "
+    hello17 = "hello world17                                                   "
+    hello18 = "hello world18                                                   "
+    hello19 = "hello world19                                                   "
+    hello20 = "hello world20                                                   "
+
+    original_data_0 = @[
+      hello01.toBytes,
+      hello02.toBytes,
+      hello03.toBytes,
+      hello04.toBytes,
+      hello05.toBytes,
+      hello06.toBytes,
+      hello07.toBytes,
+      hello08.toBytes,
+      hello09.toBytes,
+      hello10.toBytes,
+      hello11.toBytes,
+      hello12.toBytes,
+      hello13.toBytes,
+      hello14.toBytes,
+      hello15.toBytes,
+      hello16.toBytes,
+      hello17.toBytes,
+      hello18.toBytes,
+      hello19.toBytes,
+      hello20.toBytes
+    ]
+
+    original_data = Vec.new(original_data_0)
+
+  # debugEcho $original_data_0.mapIt(repr it)
+  # debugEcho $original_data.mapIt(repr cast[seq[byte]](cast[pointer](cast[int](it) - 16)))
+  debugEcho $original_data.mapIt(cast[int](it))
 
   let
     encode_work_count = leo_encode_work_count(params.original_count,
@@ -46,10 +105,15 @@ proc benchmark(params: TestParameters) =
   debugEcho "total_bytes: " & $total_bytes
 
   var
-    encode_work_data = newSeqWith(encode_work_count.int,
+    encode_work_data_0 = newSeqWith(encode_work_count.int,
       newSeq[byte](params.buffer_bytes))
-    decode_work_data = newSeqWith(decode_work_count.int,
+
+    encode_work_data = Vec.new(encode_work_data_0)
+
+    decode_work_data_0 = newSeqWith(decode_work_count.int,
       newSeq[byte](params.buffer_bytes))
+
+    decode_work_data = Vec.new(decode_work_data_0)
 
   let
     encodeResult = leo_encode(
@@ -62,6 +126,20 @@ proc benchmark(params: TestParameters) =
     )
 
   debugEcho "encodeResult: " & $leo_result_string(encodeResult)
+
+  original_data[0]  = nil
+  original_data[17] = nil
+
+  encode_work_data[0] = nil
+  encode_work_data[1] = nil
+  # encode_work_data[2] = nil
+  encode_work_data[3] = nil
+  encode_work_data[4] = nil
+  encode_work_data[5] = nil
+  encode_work_data[6] = nil
+  encode_work_data[7] = nil
+  encode_work_data[8] = nil
+  # encode_work_data[9] = nil
 
   let
     decodeResult = leo_decode(
@@ -76,10 +154,15 @@ proc benchmark(params: TestParameters) =
 
   debugEcho "decodeResult: " & $leo_result_string(decodeResult)
 
+  debugEcho $original_data.mapIt((if it.isNil: @[] else: cast[seq[byte]](cast[pointer](cast[int](it) - 16))).len)
+  debugEcho $encode_work_data.mapIt((if it.isNil: @[] else: cast[seq[byte]](cast[pointer](cast[int](it) - 16))).len)
+  debugEcho $decode_work_data.mapIt(cast[seq[byte]](cast[pointer](cast[int](it) - 16)).len)
+  # debugEcho $decode_work_data.mapIt(cast[seq[byte]](cast[pointer](cast[int](it) - 16)))
+
 proc main() =
   if leo_init() != 0: raise (ref Defect)(msg: "Leopard failed to initialize")
 
-  var params = TestParameters.init
+  var params = TestParameters.init(buffer_bytes = 64, original_count = 20)
 
   debugEcho fmt(
     "Parameters: "                              &

--- a/tests/dagger/testleopard.nim
+++ b/tests/dagger/testleopard.nim
@@ -1,0 +1,5 @@
+import pkg/dagger/leopard
+
+let lin = leo_init()
+
+echo "leo_init() return code: " & $lin

--- a/tests/dagger/testleopard.nim
+++ b/tests/dagger/testleopard.nim
@@ -2,4 +2,5 @@ import pkg/dagger/leopard
 
 let lin = leo_init()
 
+echo ""
 echo "leo_init() return code: " & $lin

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -6,5 +6,4 @@ import ./dagger/testmanifest
 import ./dagger/testnode
 import ./dagger/testleopard
 
-
 {.warning[UnusedImport]: off.}

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -4,5 +4,7 @@ import ./dagger/testasyncheapqueue
 import ./dagger/testchunking
 import ./dagger/testmanifest
 import ./dagger/testnode
+import ./dagger/testleopard
+
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
See: https://github.com/catid/leopard

This PR is not intended to come out of draft. Most likely, the wrapper will be extracted into another repo (`status-im/nim-leopard`).

My goal is to invite feedback and discussion; and I need some help as well, because it's not fully working yet.

This is my first attempt at wrapping a C++ library, though I have previous experience wrapping C libs. So there was some guesswork involved and probably mistakes. Thanks in advance for helping me sort it out!

I did the prototyping in this repo because it allows me to easily check that once libleopard is statically linked to e.g. nim-dagger's `testAll` binary, and having engaged Nim's C++ backend via the leopard wrapper (I think it does, not 100% sure), that our non-leopard Nim code still works as expected. Also, it allowed me to avoid wrestling up-front with how to wire-up a vendored Makefile and/or compiler directives in nim-leopard's `.nim` sources in a way that's flexible enough for dagger's purposes but not "hardwired" to them.

---

First, a jumble of notes about the wrapper impl and supporting changes in this PR. When I describe something that needs to be done/changed, see the changes in this PR for how I'm currently doing it.

The clang that ship's with Apple's Xcode doesn't support `-fopenmp`. Leopard's cmake config automatically checks for OpenMP support: it's detected on e.g. Ubuntu 20.04 and in a MinGW context on Windows (as seen in GHA). LLVM/clang installed on macOS with e.g. Homebrew *does* support `-fopenmp`, but for that to work some env variables need to be setup, `PATH` needs to adjusted, and some extra flags need to be passed to `cmake` and the Nim compiler.

Flags passed to `cmake` vary by platform and 64 vs. 32 bit arch. 

nim-dagger has another vendored dependency that uses `cmake`. It seems to need some changes in order for Homebrew clang/++ to be used instead of Xcode's clang on macOS:

https://github.com/status-im/nim-libbacktrace/blob/master/Makefile#L40-L41

Can probably be changed like this, but I haven't tried yet:
```Makefile
CC ?= gcc
CXX ?= g++
```
I'm also not sure if it matters that different `clang` versions are used when building `.a` that will be statically linked to the final executable.

The wrapper is fully contained in `dagger/leopard.nim`. The exported procs match up with the API presented in Leopard-RS' [readme](https://github.com/catid/leopard#encoder-api), plus `leo_result_string`:
* `leo_init`
* `leo_result_string`
* `leo_encode_work_count`
* `leo_encode`
* `leo_decode_work_count`
* `leo_decode`

In `tests/dagger/testleopard.nim` I did a rough and *minimal* port of Leopard-RS' [`tests/benchmark.cpp`](https://github.com/catid/leopard/blob/master/tests/benchmark.cpp). The only goal was/is (for now) to ensure that all procs exported from `dagger/leopard.nim` are called at least once and work as expected.

In `dagger/leopard.nim` it was necessary to use `importCpp` for `leo_init`, but for the other procs it was necessary to use `importc` instead, else the compiler fails with an error when compiling code that involves calling the proc. I don't understand why.

---

`tests/dagger/testleopard.nim` [runs successfully](https://github.com/status-im/nim-dagger/actions?query=branch%3Aleopard) on each platform/arch that we're currently testing in GHA. At the bottom of the output of `build/testAll` this is printed:
```
Parameters: [original count=100] [recovery count=10] [buffer bytes=64000] [loss count=32768] [random seed=2]
encode_work_count: 32
decode_work_count: 128
total_bytes: 6400000
encodeResult: Operation succeeded
decodeResult: Operation succeeded
```

However, the reports of `Operation succeeded` are probably misleading.

When coding the port of Leopard-RS' [`tests/benchmark.cpp`](https://github.com/catid/leopard/blob/master/tests/benchmark.cpp), I wasn't sure how to "translate" use of `std::vector` into Nim. I was also unsure about the importance of `leopard::SIMDSafeAllocate` and `leopard::SIMDSafeFree`.

I did some searching re: both, but it wasn't clear how to proceed, so I gave it a shot with Nim's `newSeqWith` and pointers obtained via `addr`. I also went with empty data (still the case in `tests/dagger/testleopard.nim` on this branch). It was encouraging to get `encodeResult: Operation succeeded` and `decodeResult: Operation succeeded`!

However, yesterday I broadened the experiment, trying to lightly replicate the recovery verification in [`tests/benchmark.cpp`](https://github.com/catid/leopard/blob/master/tests/benchmark.cpp) with non-empty `original_data` and data losses. @emizzle gave me a hand later in the day. The efforts did not succeed. No matter what was tried (with seqs and pointers) it didn't seem that `original_data` was being recovered, despite `decodeResult: Operation succeeded`.

At this point, I think it may be necessary to wrap `std::vector`, `leopard::SIMDSafeAllocate` and `leopard::SIMDSafeFree` and use them when moving data through Leopard-RS' wrapped API.

Or there may just be some misunderstanding on my part how to properly use Nim's `seq` with the API, and/or misunderstanding of how to verify data recovery / extract recovered data.