### PR TITLE
Sales

### DIFF
--- a/dagger/contracts/market.nim
+++ b/dagger/contracts/market.nim
@@ -27,10 +27,13 @@ func new*(_: type OnChainMarket, contract: Storage): OnChainMarket =
     pollInterval: DefaultPollInterval
   )
 
-method requestStorage(market: OnChainMarket, request: StorageRequest) {.async.} =
+method requestStorage(market: OnChainMarket,
+                      request: StorageRequest):
+                     Future[StorageRequest] {.async.} =
   var request = request
   request.client = await market.signer.getAddress()
   await market.contract.requestStorage(request)
+  return request
 
 method offerStorage(market: OnChainMarket, offer: StorageOffer) {.async.} =
   var offer = offer

--- a/dagger/contracts/market.nim
+++ b/dagger/contracts/market.nim
@@ -35,10 +35,13 @@ method requestStorage(market: OnChainMarket,
   await market.contract.requestStorage(request)
   return request
 
-method offerStorage(market: OnChainMarket, offer: StorageOffer) {.async.} =
+method offerStorage(market: OnChainMarket,
+                    offer: StorageOffer):
+                   Future[StorageOffer] {.async.} =
   var offer = offer
   offer.host = await market.signer.getAddress()
   await market.contract.offerStorage(offer)
+  return offer
 
 method selectOffer(market: OnChainMarket, offerId: array[32, byte]) {.async.} =
   await market.contract.selectOffer(offerId)

--- a/dagger/contracts/market.nim
+++ b/dagger/contracts/market.nim
@@ -40,7 +40,7 @@ method offerStorage(market: OnChainMarket, offer: StorageOffer) {.async.} =
 method selectOffer(market: OnChainMarket, offerId: array[32, byte]) {.async.} =
   await market.contract.selectOffer(offerId)
 
-proc getTime(market: OnChainMarket): Future[UInt256] {.async.} =
+method getTime(market: OnChainMarket): Future[UInt256] {.async.} =
   let provider = market.contract.provider
   let blck = !await provider.getBlock(BlockTag.latest)
   return blck.timestamp

--- a/dagger/market.nim
+++ b/dagger/market.nim
@@ -14,7 +14,9 @@ type
   OnOffer* = proc(offer: StorageOffer) {.gcsafe, upraises:[].}
   OnSelect* = proc(offerId: array[32, byte]) {.gcsafe, upraises: [].}
 
-method requestStorage*(market: Market, request: StorageRequest) {.base, async.} =
+method requestStorage*(market: Market,
+                       request: StorageRequest):
+                      Future[StorageRequest] {.base, async.} =
   raiseAssert("not implemented")
 
 method offerStorage*(market: Market, offer: StorageOffer) {.base, async.} =

--- a/dagger/market.nim
+++ b/dagger/market.nim
@@ -19,7 +19,9 @@ method requestStorage*(market: Market,
                       Future[StorageRequest] {.base, async.} =
   raiseAssert("not implemented")
 
-method offerStorage*(market: Market, offer: StorageOffer) {.base, async.} =
+method offerStorage*(market: Market,
+                     offer: StorageOffer):
+                    Future[StorageOffer] {.base, async.} =
   raiseAssert("not implemented")
 
 method selectOffer*(market: Market, id: array[32, byte]) {.base, async.} =

--- a/dagger/market.nim
+++ b/dagger/market.nim
@@ -46,5 +46,5 @@ method subscribeSelection*(market: Market,
                           Future[Subscription] {.base, async.} =
   raiseAssert("not implemented")
 
-method unsubscribe*(subscription: Subscription) {.base, async.} =
+method unsubscribe*(subscription: Subscription) {.base, async, upraises:[].} =
   raiseAssert("not implemented")

--- a/dagger/market.nim
+++ b/dagger/market.nim
@@ -23,6 +23,9 @@ method offerStorage*(market: Market, offer: StorageOffer) {.base, async.} =
 method selectOffer*(market: Market, id: array[32, byte]) {.base, async.} =
   raiseAssert("not implemented")
 
+method getTime*(market: Market): Future[UInt256] {.base, async.} =
+  raiseAssert("not implemented")
+
 method waitUntil*(market: Market, expiry: UInt256) {.base, async.} =
   raiseAssert("not implemented")
 

--- a/dagger/purchasing.nim
+++ b/dagger/purchasing.nim
@@ -72,10 +72,9 @@ proc run(purchase: Purchase) {.async.} =
   proc onOffer(offer: StorageOffer) =
     purchase.offers.add(offer)
   let market = purchase.market
-  let request = purchase.request
-  let subscription = await market.subscribeOffers(request.id, onOffer)
-  await market.requestStorage(request)
-  await market.waitUntil(request.expiry)
+  purchase.request = await market.requestStorage(purchase.request)
+  let subscription = await market.subscribeOffers(purchase.request.id, onOffer)
+  await market.waitUntil(purchase.request.expiry)
   await purchase.selectOffer()
   await subscription.unsubscribe()
 

--- a/dagger/sales.nim
+++ b/dagger/sales.nim
@@ -70,7 +70,8 @@ proc handleRequest(sales: Sales, request: StorageRequest) {.async.} =
   proc onSelect(offerId: array[32, byte]) {.gcsafe, upraises:[].} =
     if subscription =? subscription:
       asyncSpawn subscription.unsubscribe()
-    sales.onSale(offer)
+    if offer.id == offerId:
+      sales.onSale(offer)
   subscription = some await sales.market.subscribeSelection(request.id, onSelect)
 
 proc start*(sales: Sales) =

--- a/dagger/sales.nim
+++ b/dagger/sales.nim
@@ -1,0 +1,74 @@
+import std/sequtils
+import pkg/questionable
+import pkg/upraises
+import pkg/stint
+import pkg/nimcrypto
+import ./market
+
+export stint
+
+type
+  Sales* = ref object
+    market: Market
+    available*: seq[Availability]
+    subscription: ?Subscription
+
+  Availability* = object
+    id*: array[32, byte]
+    size*: uint64
+    duration*: uint64
+    minPrice*: UInt256
+
+func new*(_: type Sales, market: Market): Sales =
+  Sales(market: market)
+
+proc new*(_: type Availability,
+          size: uint64,
+          duration: uint64,
+          minPrice: UInt256): Availability =
+  var id: array[32, byte]
+  doAssert randomBytes(id) == 32
+  Availability(id: id, size: size, duration: duration, minPrice: minPrice)
+
+func add*(sales: Sales, availability: Availability) =
+  sales.available.add(availability)
+
+func remove*(sales: Sales, availability: Availability) =
+  sales.available.keepItIf(it != availability)
+
+func findAvailability(sales: Sales, request: StorageRequest): ?Availability =
+  for availability in sales.available:
+    if request.size <= availability.size.u256 and
+       request.duration <= availability.duration.u256 and
+       request.maxPrice >= availability.minPrice:
+      return some availability
+
+func createOffer(sales: Sales,
+                 request: StorageRequest,
+                 availability: Availability): StorageOffer =
+  StorageOffer(
+    requestId: request.id,
+    price: request.maxPrice
+  )
+
+proc handleRequest(sales: Sales, request: StorageRequest) {.async.} =
+  if availability =? sales.findAvailability(request):
+    sales.remove(availability)
+    let offer = sales.createOffer(request, availability)
+    await sales.market.offerStorage(offer)
+
+proc start*(sales: Sales) =
+  doAssert sales.subscription.isNone, "Sales already started"
+
+  proc onRequest(request: StorageRequest) {.gcsafe, upraises:[].} =
+    asyncSpawn sales.handleRequest(request)
+
+  proc subscribe {.async.} =
+    sales.subscription = some await sales.market.subscribeRequests(onRequest)
+
+  asyncSpawn subscribe()
+
+proc stop*(sales: Sales) =
+  if subscription =? sales.subscription:
+    asyncSpawn subscription.unsubscribe()
+    sales.subscription = Subscription.none

--- a/dagger/sales.nim
+++ b/dagger/sales.nim
@@ -22,7 +22,7 @@ type
 func new*(_: type Sales, market: Market): Sales =
   Sales(market: market)
 
-proc new*(_: type Availability,
+proc init*(_: type Availability,
           size: uint64,
           duration: uint64,
           minPrice: UInt256): Availability =

--- a/dagger/sales.nim
+++ b/dagger/sales.nim
@@ -73,8 +73,11 @@ proc handleRequest(sales: Sales, request: StorageRequest) {.async.} =
   proc onSelect(offerId: array[32, byte]) {.gcsafe, upraises:[].} =
     if subscription =? subscription:
       asyncSpawn subscription.unsubscribe()
-    if onSale =? sales.onSale and offer.id == offerId:
-      onSale(offer)
+    if offer.id == offerId:
+      if onSale =? sales.onSale:
+        onSale(offer)
+    else:
+      sales.add(availability)
   subscription = some await sales.market.subscribeSelection(request.id, onSelect)
 
 proc start*(sales: Sales) =

--- a/dagger/sales.nim
+++ b/dagger/sales.nim
@@ -63,8 +63,8 @@ proc handleRequest(sales: Sales, request: StorageRequest) {.async.} =
 
   sales.remove(availability)
 
-  let offer = sales.createOffer(request, availability)
-  await sales.market.offerStorage(offer)
+  var offer = sales.createOffer(request, availability)
+  offer = await sales.market.offerStorage(offer)
 
   var subscription: ?Subscription
   proc onSelect(offerId: array[32, byte]) {.gcsafe, upraises:[].} =

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -170,11 +170,11 @@ ethersuite "On-Chain Market":
     check (await market.getTime()) == latestBlock.timestamp
 
   test "supports waiting for expiry of a request or offer":
-    let pollInterval = 100.milliseconds
+    let pollInterval = 200.milliseconds
     market.pollInterval = pollInterval
 
     proc waitForPoll {.async.} =
-      await sleepAsync(pollInterval + 10.milliseconds)
+      await sleepAsync(pollInterval * 2)
 
     let future = market.waitUntil(request.expiry)
     check not future.completed

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -165,6 +165,10 @@ ethersuite "On-Chain Market":
 
     await subscription.unsubscribe()
 
+  test "can retrieve current block time":
+    let latestBlock = !await provider.getBlock(BlockTag.latest)
+    check (await market.getTime()) == latestBlock.timestamp
+
   test "supports waiting for expiry of a request or offer":
     let pollInterval = 100.milliseconds
     market.pollInterval = pollInterval

--- a/tests/dagger/examples.nim
+++ b/tests/dagger/examples.nim
@@ -6,6 +6,7 @@ import pkg/stint
 import pkg/dagger/rng
 import pkg/dagger/stores
 import pkg/dagger/blocktype
+import pkg/dagger/sales
 import ../examples
 
 export examples
@@ -51,3 +52,6 @@ proc example*(_: type BlockExcPeerCtx): BlockExcPeerCtx =
 
 proc example*(_: type Cid): Cid =
   Block.example.cid
+
+proc example*(_: type Availability): Availability =
+  Availability.new(uint16.example, uint16.example, uint64.example.u256)

--- a/tests/dagger/examples.nim
+++ b/tests/dagger/examples.nim
@@ -54,4 +54,4 @@ proc example*(_: type Cid): Cid =
   Block.example.cid
 
 proc example*(_: type Availability): Availability =
-  Availability.new(uint16.example, uint16.example, uint64.example.u256)
+  Availability.init(uint16.example, uint16.example, uint64.example.u256)

--- a/tests/dagger/helpers/mockmarket.nim
+++ b/tests/dagger/helpers/mockmarket.nim
@@ -2,6 +2,8 @@ import std/sequtils
 import std/heapqueue
 import pkg/dagger/market
 
+export market
+
 type
   MockMarket* = ref object of Market
     requested*: seq[StorageRequest]

--- a/tests/dagger/helpers/mockmarket.nim
+++ b/tests/dagger/helpers/mockmarket.nim
@@ -32,11 +32,14 @@ type
     future: Future[void]
     expiry: UInt256
 
-method requestStorage*(market: MockMarket, request: StorageRequest) {.async.} =
+method requestStorage*(market: MockMarket,
+                       request: StorageRequest):
+                      Future[StorageRequest] {.async.} =
   market.requested.add(request)
   let subscriptions = market.subscriptions.onRequest
   for subscription in subscriptions:
     subscription.callback(request)
+  return request
 
 method offerStorage*(market: MockMarket, offer: StorageOffer) {.async.} =
   market.offered.add(offer)

--- a/tests/dagger/helpers/mockmarket.nim
+++ b/tests/dagger/helpers/mockmarket.nim
@@ -41,12 +41,15 @@ method requestStorage*(market: MockMarket,
     subscription.callback(request)
   return request
 
-method offerStorage*(market: MockMarket, offer: StorageOffer) {.async.} =
+method offerStorage*(market: MockMarket,
+                     offer: StorageOffer):
+                    Future[StorageOffer] {.async.} =
   market.offered.add(offer)
   let subscriptions = market.subscriptions.onOffer
   for subscription in subscriptions:
     if subscription.requestId == offer.requestId:
       subscription.callback(offer)
+  return offer
 
 proc findOffer(market: MockMarket, id: array[32, byte]): ?StorageOffer =
   for offer in market.offered:

--- a/tests/dagger/helpers/mockmarket.nim
+++ b/tests/dagger/helpers/mockmarket.nim
@@ -71,6 +71,9 @@ method unsubscribe*(subscription: OfferSubscription) {.async.} =
 func `<`(a, b: Expiry): bool =
   a.expiry < b.expiry
 
+method getTime*(market: MockMarket): Future[UInt256] {.async.} =
+  return market.time
+
 method waitUntil*(market: MockMarket, expiry: UInt256): Future[void] =
   let future = Future[void]()
   if expiry > market.time:

--- a/tests/dagger/testpurchasing.nim
+++ b/tests/dagger/testpurchasing.nim
@@ -79,8 +79,8 @@ suite "Purchasing":
     var offer1, offer2 = createOffer(request)
     offer1.price = 20.u256
     offer2.price = 10.u256
-    await market.offerStorage(offer1)
-    await market.offerStorage(offer2)
+    discard await market.offerStorage(offer1)
+    discard await market.offerStorage(offer2)
     market.advanceTimeTo(request.expiry)
     await purchase.wait()
     check market.selected[0] == offer2.id
@@ -93,8 +93,8 @@ suite "Purchasing":
     offer1.price = 20.u256
     offer2.price = 10.u256
     offer2.expiry = expired
-    await market.offerStorage(offer1)
-    await market.offerStorage(offer2)
+    discard await market.offerStorage(offer1)
+    discard await market.offerStorage(offer2)
     market.advanceTimeTo(request.expiry)
     await purchase.wait()
     check market.selected[0] == offer1.id
@@ -110,8 +110,8 @@ suite "Purchasing":
     offer1.price = 20.u256
     offer2.price = 10.u256
     offer2.expiry = getTime().toUnix().u256 + expiryMargin - 1
-    await market.offerStorage(offer1)
-    await market.offerStorage(offer2)
+    discard await market.offerStorage(offer1)
+    discard await market.offerStorage(offer2)
     market.advanceTimeTo(request.expiry)
     await purchase.wait()
     check market.selected[0] == offer1.id

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -88,3 +88,18 @@ suite "Sales":
     await market.selectOffer(offer.id)
     check selectedOffer == offer
     sales.stop()
+
+  test "does not call onSale when a different offer is selected":
+    let availability = Availability.init(size=100, duration=60, minPrice=42.u256)
+    sales.add(availability)
+    var onSaleWasCalled: bool
+    sales.onSale = proc(offer: StorageOffer) =
+      onSaleWasCalled = true
+    sales.start()
+    var request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
+    request = await market.requestStorage(request)
+    var otherOffer = StorageOffer(requestId: request.id, price: 1.u256)
+    otherOffer = await market.offerStorage(otherOffer)
+    await market.selectOffer(otherOffer.id)
+    check not onSaleWasCalled
+    sales.stop()

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -87,3 +87,11 @@ suite "Sales":
     otherOffer = await market.offerStorage(otherOffer)
     await market.selectOffer(otherOffer.id)
     check not didSell
+
+  test "makes storage available again when different offer is selected":
+    sales.add(availability)
+    let request = await market.requestStorage(request)
+    var otherOffer = StorageOffer(requestId: request.id, price: 1.u256)
+    otherOffer = await market.offerStorage(otherOffer)
+    await market.selectOffer(otherOffer.id)
+    check sales.available.contains(availability)

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -95,3 +95,11 @@ suite "Sales":
     otherOffer = await market.offerStorage(otherOffer)
     await market.selectOffer(otherOffer.id)
     check sales.available.contains(availability)
+
+  test "makes storage available again when offer expires":
+    sales.add(availability)
+    discard await market.requestStorage(request)
+    let offer = market.offered[0]
+    market.advanceTimeTo(offer.expiry)
+    await sleepAsync(chronos.seconds(1))
+    check sales.available.contains(availability)

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -74,3 +74,17 @@ suite "Sales":
     await market.requestStorage(request)
     check market.offered[0].expiry == now + sales.offerExpiryInterval
     sales.stop()
+
+  test "call onSale when offer is selected":
+    let availability = Availability.init(size=100, duration=60, minPrice=42.u256)
+    sales.add(availability)
+    var selectedOffer: StorageOffer
+    sales.onSale = proc(offer: StorageOffer) =
+      selectedOffer = offer
+    sales.start()
+    let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
+    await market.requestStorage(request)
+    let offer = market.offered[0]
+    await market.selectOffer(offer.id)
+    check selectedOffer == offer
+    sales.stop()

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -32,12 +32,12 @@ suite "Sales":
     check sales.available.len == 0
 
   test "generates unique ids for storage availability":
-    let availability1 = Availability.new(size=1, duration=2, minPrice=3.u256)
-    let availability2 = Availability.new(size=1, duration=2, minPrice=3.u256)
+    let availability1 = Availability.init(size=1, duration=2, minPrice=3.u256)
+    let availability2 = Availability.init(size=1, duration=2, minPrice=3.u256)
     check availability1.id != availability2.id
 
   test "offers available storage when matching request comes in":
-    let availability = Availability.new(size=100, duration=60, minPrice=42.u256)
+    let availability = Availability.init(size=100, duration=60, minPrice=42.u256)
     sales.add(availability)
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
@@ -47,7 +47,7 @@ suite "Sales":
     sales.stop()
 
   test "ignores request when no matching storage is available":
-    let availability = Availability.new(size=99, duration=60, minPrice=42.u256)
+    let availability = Availability.init(size=99, duration=60, minPrice=42.u256)
     sales.add(availability)
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
@@ -56,7 +56,7 @@ suite "Sales":
     sales.stop()
 
   test "makes storage unavailable when offer is submitted":
-    let availability = Availability.new(size=100, duration=60, minPrice=42.u256)
+    let availability = Availability.init(size=100, duration=60, minPrice=42.u256)
     sales.add(availability)
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -42,7 +42,7 @@ suite "Sales":
     sales.add(availability)
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
-    await market.requestStorage(request)
+    discard await market.requestStorage(request)
     check market.offered.len == 1
     check market.offered[0].price == 42.u256
     sales.stop()
@@ -52,7 +52,7 @@ suite "Sales":
     sales.add(availability)
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
-    await market.requestStorage(request)
+    discard await market.requestStorage(request)
     check market.offered.len == 0
     sales.stop()
 
@@ -61,7 +61,7 @@ suite "Sales":
     sales.add(availability)
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
-    await market.requestStorage(request)
+    discard await market.requestStorage(request)
     check sales.available.len == 0
     sales.stop()
 
@@ -71,7 +71,7 @@ suite "Sales":
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
     let now = getTime().toUnix().u256
-    await market.requestStorage(request)
+    discard await market.requestStorage(request)
     check market.offered[0].expiry == now + sales.offerExpiryInterval
     sales.stop()
 
@@ -83,7 +83,7 @@ suite "Sales":
       selectedOffer = offer
     sales.start()
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
-    await market.requestStorage(request)
+    discard await market.requestStorage(request)
     let offer = market.offered[0]
     await market.selectOffer(offer.id)
     check selectedOffer == offer

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -1,0 +1,65 @@
+import pkg/asynctest
+import pkg/chronos
+import pkg/dagger/sales
+import ./helpers/mockmarket
+import ./examples
+
+suite "Sales":
+
+  var sales: Sales
+  var market: MockMarket
+
+  setup:
+    market = MockMarket.new()
+    sales = Sales.new(market)
+
+  test "has no availability initially":
+    check sales.available.len == 0
+
+  test "can add available storage":
+    let availability1 = Availability.example
+    let availability2 = Availability.example
+    sales.add(availability1)
+    check sales.available.contains(availability1)
+    sales.add(availability2)
+    check sales.available.contains(availability1)
+    check sales.available.contains(availability2)
+
+  test "can remove available storage":
+    let availability = Availability.example
+    sales.add(availability)
+    sales.remove(availability)
+    check sales.available.len == 0
+
+  test "generates unique ids for storage availability":
+    let availability1 = Availability.new(size=1, duration=2, minPrice=3.u256)
+    let availability2 = Availability.new(size=1, duration=2, minPrice=3.u256)
+    check availability1.id != availability2.id
+
+  test "offers available storage when matching request comes in":
+    let availability = Availability.new(size=100, duration=60, minPrice=42.u256)
+    sales.add(availability)
+    sales.start()
+    let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
+    await market.requestStorage(request)
+    check market.offered.len == 1
+    check market.offered[0].price == 42.u256
+    sales.stop()
+
+  test "ignores request when no matching storage is available":
+    let availability = Availability.new(size=99, duration=60, minPrice=42.u256)
+    sales.add(availability)
+    sales.start()
+    let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
+    await market.requestStorage(request)
+    check market.offered.len == 0
+    sales.stop()
+
+  test "makes storage unavailable when offer is submitted":
+    let availability = Availability.new(size=100, duration=60, minPrice=42.u256)
+    sales.add(availability)
+    sales.start()
+    let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
+    await market.requestStorage(request)
+    check sales.available.len == 0
+    sales.stop()

--- a/tests/dagger/testsales.nim
+++ b/tests/dagger/testsales.nim
@@ -1,3 +1,4 @@
+import std/times
 import pkg/asynctest
 import pkg/chronos
 import pkg/dagger/sales
@@ -62,4 +63,14 @@ suite "Sales":
     let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
     await market.requestStorage(request)
     check sales.available.len == 0
+    sales.stop()
+
+  test "sets expiry time of offer":
+    let availability = Availability.init(size=100, duration=60, minPrice=42.u256)
+    sales.add(availability)
+    sales.start()
+    let request = StorageRequest(duration:60.u256, size:100.u256, maxPrice:42.u256)
+    let now = getTime().toUnix().u256
+    await market.requestStorage(request)
+    check market.offered[0].expiry == now + sales.offerExpiryInterval
     sales.stop()

--- a/tests/testDagger.nim
+++ b/tests/testDagger.nim
@@ -6,5 +6,6 @@ import ./dagger/testmanifest
 import ./dagger/testnode
 import ./dagger/teststorestream
 import ./dagger/testpurchasing
+import ./dagger/testsales
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
Adds a simple sales algorithm that watches for storage request, and offers storage if it has matching available storage.

Does not yet include persistent state, so it won't be able to recover from a node shutdown in the middle of a sale.